### PR TITLE
ユーザー論理削除機能、画面作成

### DIFF
--- a/components/user/deleteDialog.vue
+++ b/components/user/deleteDialog.vue
@@ -14,7 +14,7 @@
         <v-card-title class="text-h5">確認</v-card-title>
         <v-card-item>
           <v-card-text>
-            本当にユーザー「{{ props.user.username }}」を削除しますか？
+            本当にユーザー「{{ props.user.username }}」を利用停止にしますか？
           </v-card-text>
         </v-card-item>
         <v-card-actions>

--- a/components/user/deleteDialog.vue
+++ b/components/user/deleteDialog.vue
@@ -1,0 +1,68 @@
+<template>
+  <v-dialog v-model="isActive" max-width="500">
+    <template v-slot:activator="{ props: activatorProps }">
+      <v-btn
+        v-bind="activatorProps"
+        color="surface-variant"
+        text="利用停止"
+        variant="flat"
+      ></v-btn>
+    </template>
+
+    <template v-slot:default="{ isActive }">
+      <v-card>
+        <v-card-title class="text-h5">確認</v-card-title>
+        <v-card-item>
+          <v-card-text>
+            本当にユーザー「{{ props.user.username }}」を削除しますか？
+          </v-card-text>
+        </v-card-item>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn
+            text="利用停止"
+            @click="_deleteUser"
+          ></v-btn>
+          <v-btn
+            text="キャンセル"
+            @click="isActive.value = false"
+          ></v-btn>
+        </v-card-actions>
+      </v-card>
+    </template>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useUser } from '~/composables/useUser';
+
+const { deleteUser } = useUser();
+
+// user プロップを受け取る
+const props = defineProps<{
+  user: {
+    id: number;
+    username: string;
+    email: string;
+    disabled: boolean;
+    role: string;
+  };
+}>();
+
+const emit = defineEmits(['userUpdated']);
+
+// フォームのバリデーション状態
+const isActive = ref<boolean>(false); // モーダルのアクティブ状態を管理
+
+const _deleteUser = async () => {
+  const success = await deleteUser(props.user.id, true);
+  if (success) {
+    isActive.value = false; // 更新が成功した場合にモーダルを閉じる
+    emit('userUpdated'); // 更新成功時にイベントを発火
+  }
+};
+</script>
+
+<style scoped>
+</style>

--- a/composables/useAuth.ts
+++ b/composables/useAuth.ts
@@ -31,7 +31,7 @@ export const useAuth = () => {
 
   const logOut = async () => {
     authStore.logout();
-    navigateTo('/auth/login');
+    navigateTo('/');
   };
 
   return {

--- a/composables/useUser.ts
+++ b/composables/useUser.ts
@@ -80,10 +80,37 @@ export const useUser = () => {
     }
   }
 
+  const deleteUser = async (userId: number, disabled: boolean) => {
+    authStore.loadToken();
+    try {
+      const response = await fetch(`${apiBaseUrl}/api/users/disabled?user_id=${userId}`, {
+        method: 'PUT',
+        headers: {
+          'Authorization': `Bearer ${authStore.token}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          disabled: disabled
+        })
+      })
+      const data: UserResponse = await response.json()
+      if (response.ok) {
+        return true;
+      } else  {
+        alert(data.error)
+        return false;
+      }
+    } catch (error) {
+      console.error('An error occurred:', error)
+      return false;
+    }
+  }
+
   return {
     signUp,
     fetchUsers,
     updateUser,
+    deleteUser,
     users
   };
 };

--- a/composables/useUser.ts
+++ b/composables/useUser.ts
@@ -23,7 +23,7 @@ export const useUser = () => {
       })
       const data: UserResponse = await response.json()
       if (response.ok) {
-        navigateTo('/auth/login')
+        navigateTo('/')
       } else  {
         alert(data.error)
       }

--- a/pages/auth/signUp.vue
+++ b/pages/auth/signUp.vue
@@ -34,7 +34,7 @@
     </v-card-text>
     <v-card-actions class="d-flex justify-center">
       <p class="sign_up_link">ログインしますか？<br>
-        <router-link to="/auth/login">ログインはこちら</router-link>
+        <router-link to="/">ログインはこちら</router-link>
       </p>
     </v-card-actions>
   </v-card>

--- a/pages/user/index.vue
+++ b/pages/user/index.vue
@@ -29,7 +29,8 @@
           </v-card-text>
           <v-card-actions>
             <v-spacer />
-            <updateDialog :user="user" @userUpdated="fetchUsers"/>
+            <updateDialog :user="user" @userUpdated="fetchUsers" />
+            <deleteDialog :user="user" @userUpdated="fetchUsers" />
           </v-card-actions>
         </v-card>
       </v-col>
@@ -41,6 +42,7 @@
 import { onMounted } from 'vue'
 import { useUser } from '~/composables/useUser';
 import updateDialog from '~/components/user/updateDialog.vue';
+import deleteDialog from '~/components/user/deleteDialog.vue';
 
 const { users, fetchUsers } = useUser(); // useUserフックからデータを取得
 


### PR DESCRIPTION
## Description
- components/user/deleteDialog.vue
  - 一覧画面利用停止ボタンクリック後のダイアログ作成
- composables/useUser.ts
  - ユーザー利用停止関数作成
- pages/user/index.vue
  - 利用停止ボタン追加
- composables/useAuth.ts
  - ログイン画面へのパスを変更
## image
![スクリーンショット 2024-10-01 10 40 15（2）](https://github.com/user-attachments/assets/a514e584-7312-47f5-aacf-3d7cec76e789)


## Related Issues
<!--
- Add issue in other repo/url.
-->
## Review Checklist
<!--
- [ ] what to check (@foobar)
-->
## TODO
なし
<!--
- [ ] what need to be done.
  - Reason not finished in this PR.
-->
## Breaking Change
No
<!--
- Describe the impact if Yes.
-->