### PR TITLE
ユーザー編集画面作成

### DIFF
--- a/components/user/updateDialog.vue
+++ b/components/user/updateDialog.vue
@@ -86,15 +86,9 @@ const valid = ref<boolean>(false); // フォームのバリデーション結果
 // v : 検証対象の値
 // v.length <= 50: vの長さを指定
 // false : バリデーションが失敗した場合エラーメッセージ表示
-const nameRules = [
-  (v: string) => v.length <= 20 || 'ユーザー名は20文字以内である必要があります',
-];
-const emailRules = [
-  (v: string) => v.length <= 50 || 'メールアドレスは50文字以内である必要があります',
-];
-const passwordRules = [
-  (v: string) => v.length <= 10 || 'パスワードは10文字以内である必要があります',
-];
+const nameRules = (v: string) => v.length <= 20 || 'ユーザー名は20文字以内である必要があります';
+const emailRules = (v: string) => v.length <= 50 || 'メールアドレスは50文字以内である必要があります';
+const passwordRules = (v: string) => v.length <= 10 || 'パスワードは10文字以内である必要があります';
 
 const _updateUser = async () => {
   const success = await updateUser(props.user.id, username.value, email.value, password.value, role.value);

--- a/components/user/updateDialog.vue
+++ b/components/user/updateDialog.vue
@@ -10,23 +10,27 @@
   </template>
 
   <template v-slot:default="{ isActive }">
-    <v-card title="ユーザー編集">
+    <v-card>
+      <v-card-title class="text-h5">ユーザー編集</v-card-title>
       <v-card-item>
         <v-form>
           <v-text-field
             v-model="username"
             label="ユーザー名"
             hide-details
+            class="mb-1"
           ></v-text-field>
           <v-text-field
             v-model="email"
             label="メールアドレス"
             hide-details
+            class="mb-1"
           ></v-text-field>
           <v-text-field
             v-model="password"
             label="パスワード"
             hide-details
+            class="mb-1"
           ></v-text-field>
           <v-select
             v-model="role"

--- a/components/user/updateDialog.vue
+++ b/components/user/updateDialog.vue
@@ -13,24 +13,24 @@
     <v-card>
       <v-card-title class="text-h5">ユーザー編集</v-card-title>
       <v-card-item>
-        <v-form>
+        <v-form v-model="valid">
           <v-text-field
             v-model="username"
+            :rules="nameRules"
+            :counter="20"
             label="ユーザー名"
-            hide-details
-            class="mb-1"
           ></v-text-field>
           <v-text-field
             v-model="email"
+            :rules="emailRules"
+            :counter="50"
             label="メールアドレス"
-            hide-details
-            class="mb-1"
           ></v-text-field>
           <v-text-field
             v-model="password"
+            :rules="passwordRules"
+            :counter="10"
             label="パスワード"
-            hide-details
-            class="mb-1"
           ></v-text-field>
           <v-select
             v-model="role"
@@ -44,6 +44,7 @@
         <v-btn
           text="編集"
           @click="_updateUser"
+          :disabled="!valid"
         ></v-btn>
         <v-btn
           text="閉じる"
@@ -59,6 +60,8 @@
 import { ref } from 'vue';
 import { useUser } from '~/composables/useUser';
 
+const { updateUser } = useUser();
+
 // user プロップを受け取る
 const props = defineProps<{
   user: {
@@ -72,14 +75,26 @@ const props = defineProps<{
 
 const emit = defineEmits(['userUpdated']);
 
-// フォームのバリデーション状態
 const username = ref<string>(props.user.username);
 const email = ref<string>(props.user.email);
 const password = ref<string>('');
 const role = ref<string>(props.user.role)
 const isActive = ref<boolean>(false); // モーダルのアクティブ状態を管理
+const valid = ref<boolean>(false); // フォームのバリデーション結果を管理
 
-const { updateUser } = useUser();
+// バリデーションルール
+// v : 検証対象の値
+// v.length <= 50: vの長さを指定
+// false : バリデーションが失敗した場合エラーメッセージ表示
+const nameRules = [
+  (v: string) => v.length <= 20 || 'ユーザー名は20文字以内である必要があります',
+];
+const emailRules = [
+  (v: string) => v.length <= 50 || 'メールアドレスは50文字以内である必要があります',
+];
+const passwordRules = [
+  (v: string) => v.length <= 10 || 'パスワードは10文字以内である必要があります',
+];
 
 const _updateUser = async () => {
   const success = await updateUser(props.user.id, username.value, email.value, password.value, role.value);

--- a/components/user/updateDialog.vue
+++ b/components/user/updateDialog.vue
@@ -52,7 +52,7 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps, defineEmits, ref } from 'vue';
+import { ref } from 'vue';
 import { useUser } from '~/composables/useUser';
 
 // user プロップを受け取る

--- a/components/user/updateDialog.vue
+++ b/components/user/updateDialog.vue
@@ -16,19 +16,19 @@
         <v-form v-model="valid">
           <v-text-field
             v-model="username"
-            :rules="nameRules"
+            :rules="[nameRules]"
             :counter="20"
             label="ユーザー名"
           ></v-text-field>
           <v-text-field
             v-model="email"
-            :rules="emailRules"
+            :rules="[emailRules]"
             :counter="50"
             label="メールアドレス"
           ></v-text-field>
           <v-text-field
             v-model="password"
-            :rules="passwordRules"
+            :rules="[passwordRules]"
             :counter="10"
             label="パスワード"
           ></v-text-field>

--- a/components/user/updateDialog.vue
+++ b/components/user/updateDialog.vue
@@ -52,7 +52,7 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps, ref } from 'vue';
+import { defineProps, defineEmits, ref } from 'vue';
 import { useUser } from '~/composables/useUser';
 
 // user プロップを受け取る
@@ -65,6 +65,8 @@ const props = defineProps<{
     role: string;
   };
 }>();
+
+const emit = defineEmits(['userUpdated']);
 
 // フォームのバリデーション状態
 const username = ref(props.user.username);
@@ -79,6 +81,7 @@ const _updateUser = async () => {
   const success = await updateUser(props.user.id, username.value, email.value, password.value, role.value);
   if (success) {
     isActive.value = false; // 更新が成功した場合にモーダルを閉じる
+    emit('userUpdated'); // 更新成功時にイベントを発火
   }
 };
 

--- a/components/user/updateDialog.vue
+++ b/components/user/updateDialog.vue
@@ -73,11 +73,11 @@ const props = defineProps<{
 const emit = defineEmits(['userUpdated']);
 
 // フォームのバリデーション状態
-const username = ref(props.user.username);
-const email = ref(props.user.email);
-const password = ref('');
-const role = ref(props.user.role)
-const isActive = ref(false); // モーダルのアクティブ状態を管理
+const username = ref<string>(props.user.username);
+const email = ref<string>(props.user.email);
+const password = ref<string>('');
+const role = ref<string>(props.user.role)
+const isActive = ref<boolean>(false); // モーダルのアクティブ状態を管理
 
 const { updateUser } = useUser();
 

--- a/components/user/updateDialog.vue
+++ b/components/user/updateDialog.vue
@@ -1,0 +1,88 @@
+<template>
+  <v-dialog v-model="isActive" max-width="500">
+  <template v-slot:activator="{ props: activatorProps }">
+    <v-btn
+      v-bind="activatorProps"
+      color="surface-variant"
+      text="編集"
+      variant="flat"
+    ></v-btn>
+  </template>
+
+  <template v-slot:default="{ isActive }">
+    <v-card title="ユーザー編集">
+      <v-card-item>
+        <v-form>
+          <v-text-field
+            v-model="username"
+            label="ユーザー名"
+            hide-details
+          ></v-text-field>
+          <v-text-field
+            v-model="email"
+            label="メールアドレス"
+            hide-details
+          ></v-text-field>
+          <v-text-field
+            v-model="password"
+            label="パスワード"
+            hide-details
+          ></v-text-field>
+          <v-select
+            v-model="role"
+            label="Select"
+            :items="['admin', 'user']"
+          ></v-select>
+        </v-form>
+      </v-card-item>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn
+          text="編集"
+          @click="_updateUser"
+        ></v-btn>
+        <v-btn
+          text="閉じる"
+          @click="isActive.value = false"
+        ></v-btn>
+      </v-card-actions>
+    </v-card>
+  </template>
+</v-dialog>
+</template>
+
+<script setup lang="ts">
+import { defineProps, ref } from 'vue';
+import { useUser } from '~/composables/useUser';
+
+// user プロップを受け取る
+const props = defineProps<{
+  user: {
+    id: number;
+    username: string;
+    email: string;
+    disabled: boolean;
+    role: string;
+  };
+}>();
+
+// フォームのバリデーション状態
+const username = ref(props.user.username);
+const email = ref(props.user.email);
+const password = ref('');
+const role = ref(props.user.role)
+const isActive = ref(false); // モーダルのアクティブ状態を管理
+
+const { updateUser } = useUser();
+
+const _updateUser = async () => {
+  const success = await updateUser(props.user.id, username.value, email.value, password.value, role.value);
+  if (success) {
+    isActive.value = false; // 更新が成功した場合にモーダルを閉じる
+  }
+};
+
+</script>
+
+<style scoped>
+</style>

--- a/composables/useUser.ts
+++ b/composables/useUser.ts
@@ -52,9 +52,38 @@ export const useUser = () => {
     }
   };
 
+  const updateUser = async (userId: number, username: string, email: string, password: string, role: string) => {
+    authStore.loadToken();
+    try {
+      const response = await fetch(`${apiBaseUrl}/api/user/update?user_id=${userId}`, {
+        method: 'PUT',
+        headers: {
+          'Authorization': `Bearer ${authStore.token}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          username: username,
+          email: email,
+          password: password,
+          role: role
+        })
+      })
+      const data: UserResponse = await response.json()
+      if (response.ok) {
+        return true;
+      } else  {
+        alert(data.error)
+        return false;
+      }
+    } catch (error) {
+      console.error('An error occurred:', error)
+    }
+  }
+
   return {
     signUp,
     fetchUsers,
+    updateUser,
     users
   };
 };

--- a/pages/user/index.vue
+++ b/pages/user/index.vue
@@ -27,7 +27,7 @@
               <strong>役割:</strong> {{ user.role }}
             </div>
           </v-card-text>
-          <updateDialog :user="user"/>
+          <updateDialog :user="user" @userUpdated="fetchUsers"/>
         </v-card>
       </v-col>
     </v-row>

--- a/pages/user/index.vue
+++ b/pages/user/index.vue
@@ -27,7 +27,10 @@
               <strong>役割:</strong> {{ user.role }}
             </div>
           </v-card-text>
-          <updateDialog :user="user" @userUpdated="fetchUsers"/>
+          <v-card-actions>
+            <v-spacer />
+            <updateDialog :user="user" @userUpdated="fetchUsers"/>
+          </v-card-actions>
         </v-card>
       </v-col>
     </v-row>

--- a/pages/user/index.vue
+++ b/pages/user/index.vue
@@ -27,6 +27,7 @@
               <strong>役割:</strong> {{ user.role }}
             </div>
           </v-card-text>
+          <updateDialog :user="user"/>
         </v-card>
       </v-col>
     </v-row>
@@ -36,6 +37,7 @@
 <script setup lang="ts">
 import { onMounted } from 'vue'
 import { useUser } from '~/composables/useUser';
+import updateDialog from '~/components/user/updateDialog.vue';
 
 const { users, fetchUsers } = useUser(); // useUserフックからデータを取得
 


### PR DESCRIPTION
## Description
- components/user/updateDialog.vue
  - ユーザー一覧画面の編集ボタンクリック後のダイアログを作成
  - バリデーションを追加
- pages/user/index.vue
  - ユーザー一覧画面に編集ボタン追加
- composables/useUser.ts
  - ユーザー編集関数追加
## image
![スクリーンショット 2024-10-01 11 32 41（2）](https://github.com/user-attachments/assets/b4bb4e52-c1b7-4eaf-83bf-a598332ebcde)

## Related Issues
<!--
- Add issue in other repo/url.
-->
## Review Checklist
<!--
- [ ] what to check (@foobar)
-->
## TODO
なし
<!--
- [ ] what need to be done.
  - Reason not finished in this PR.
-->
## Breaking Change
No
<!--
- Describe the impact if Yes.
-->