### PR TITLE
タスク編集画面作成

### DIFF
--- a/components/tasks/updateDialog.vue
+++ b/components/tasks/updateDialog.vue
@@ -1,0 +1,124 @@
+<template>
+  <v-dialog v-model="isActive" max-width="500">
+  <template v-slot:activator="{ props: activatorProps }">
+    <v-btn
+      v-bind="activatorProps"
+      color="surface-variant"
+      text="編集"
+      variant="flat"
+    ></v-btn>
+  </template>
+
+  <template v-slot:default="{ isActive }">
+    <v-card>
+      <v-card-title class="text-h5">タスク編集</v-card-title>
+      <v-card-item>
+        <v-form v-model="valid">
+          <v-text-field
+            v-model="title"
+            :rules="[titleRules]"
+            :counter="20"
+            label="タイトル"
+          ></v-text-field>
+          <v-text-field
+            v-model="description"
+            :rules="[descriptionRules]"
+            :counter="50"
+            label="説明"
+          ></v-text-field>
+          <v-select
+            v-model="completed"
+            label="完了状態"
+            item-title="title"
+            item-value="value"
+            :items="[
+                { title: '完了', value: true },
+                { title: '未完了', value: false }
+              ]"
+          ></v-select>
+          <v-select
+            v-model="tags"
+            label="関連タグ"
+            item-title="name"
+            item-value="id"
+            :items="tagsItems"
+            multiple
+            @change="updateSelectedTags"
+          ></v-select>
+        </v-form>
+      </v-card-item>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn
+          text="編集"
+          @click="_updateTask"
+          :disabled="!valid"
+        ></v-btn>
+        <v-btn
+          text="閉じる"
+          @click="isActive.value = false"
+        ></v-btn>
+      </v-card-actions>
+    </v-card>
+  </template>
+</v-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useTask } from '~/composables/useTask';
+import { useTag } from '~/composables/useTag';
+import type { TagResponse } from '~/types/tag';
+
+const { updateTask } = useTask();
+
+// user プロップを受け取る
+const props = defineProps<{
+  task: {
+    id: number;
+    title: string;
+    description: string;
+    completed: boolean;
+    tags: TagResponse[];
+  };
+}>();
+
+const emit = defineEmits(['taskUpdated']);
+
+const title = ref<string>(props.task.title);
+const description = ref<string>(props.task.description);
+const completed = ref<boolean>(props.task.completed);
+const tags = ref<number[]>(props.task.tags.map(tag => tag.id)); // タグIDの配列
+const isActive = ref<boolean>(false); // モーダルのアクティブ状態を管理
+const valid = ref<boolean>(false); // フォームのバリデーション結果を管理
+const tagsItems = ref<TagResponse[]>([]);// タグのリストを格納するためのref
+
+const { fetchTags, tags: fetchedTags } = useTag();
+
+// バリデーションルール
+// v : 検証対象の値
+// v.length <= 50: vの長さを指定
+// false : バリデーションが失敗した場合エラーメッセージ表示
+const titleRules = (v: string) => v.length <= 20 || 'タイトルは20文字以内である必要があります';
+const descriptionRules = (v: string) => v.length <= 50 || '説明は50文字以内である必要があります';
+
+const updateSelectedTags = (selectedTags: TagResponse[]) => {
+  tags.value = selectedTags.map(tag => tag.id);; // 選択されたタグのオブジェクトをセット
+};
+
+const _updateTask = async () => {
+  const success = await updateTask(props.task.id, title.value, description.value, completed.value, tags.value); // IDの配列を送信
+  if (success) {
+    isActive.value = false; // 更新が成功した場合にモーダルを閉じる
+    emit('taskUpdated'); // 更新成功時にイベントを発火
+  }
+};
+
+onMounted(async () => {
+  await fetchTags();
+  tagsItems.value = fetchedTags.value; // 取得したタグを格納
+});
+</script>
+
+<style scoped>
+</style>

--- a/components/tasks/updateDialog.vue
+++ b/components/tasks/updateDialog.vue
@@ -72,7 +72,6 @@ import type { TagResponse } from '~/types/tag';
 
 const { updateTask } = useTask();
 
-// user プロップを受け取る
 const props = defineProps<{
   task: {
     id: number;

--- a/components/tasks/updateDialog.vue
+++ b/components/tasks/updateDialog.vue
@@ -88,7 +88,7 @@ const emit = defineEmits(['taskUpdated']);
 const title = ref<string>(props.task.title);
 const description = ref<string>(props.task.description);
 const completed = ref<boolean>(props.task.completed);
-const tags = ref<number[]>(props.task.tags.map(tag => tag.id)); // タグIDの配列
+const tags = ref<number[]>(props.task.tags.map(tag => tag.id)); // props.task.tagsの配列から各tagのidプロパティを取得し、それを新しい配列としてtagsに格納
 const isActive = ref<boolean>(false); // モーダルのアクティブ状態を管理
 const valid = ref<boolean>(false); // フォームのバリデーション結果を管理
 const tagsItems = ref<TagResponse[]>([]);// タグのリストを格納するためのref
@@ -102,6 +102,7 @@ const { fetchTags, tags: fetchedTags } = useTag();
 const titleRules = (v: string) => v.length <= 20 || 'タイトルは20文字以内である必要があります';
 const descriptionRules = (v: string) => v.length <= 50 || '説明は50文字以内である必要があります';
 
+//tagsItemsから選択されたタグオブジェクトがselectedTags
 const updateSelectedTags = (selectedTags: TagResponse[]) => {
   tags.value = selectedTags.map(tag => tag.id);; // 選択されたタグのオブジェクトをセット
 };

--- a/composables/useTag.ts
+++ b/composables/useTag.ts
@@ -1,0 +1,34 @@
+import { ref } from 'vue';
+import { apiBaseUrl } from '../config';
+import type { TagResponse } from '~/types/tag';
+import { useAuthStore } from '~/store/auth';
+
+export const useTag = () => {
+  const tags = ref<TagResponse[]>([]);
+  const authStore = useAuthStore();
+
+  const fetchTags = async () => {
+    authStore.loadToken();
+    try {
+      const response = await fetch(`${apiBaseUrl}/api/tags`, {
+        headers: {
+          'Authorization': `Bearer ${authStore.token}`
+        },
+      });
+      const data: TagResponse[] = await response.json();  // データを先に取得しておく
+      if (response.ok) {
+        tags.value = data;
+      } else {
+        alert(data[0]?.error || '不明なエラーが発生しました');
+      }
+    } catch (err) {
+      console.error('An error occurred:', err);
+      alert('タスクの取得に失敗しました');
+    }
+  };
+
+  return {
+    fetchTags,
+    tags
+  };
+};

--- a/composables/useTask.ts
+++ b/composables/useTask.ts
@@ -1,6 +1,7 @@
 import { ref } from 'vue';
 import { apiBaseUrl } from '../config';
 import type { TaskResponse } from '~/types/task';
+import type { TagResponse } from '~/types/tag';
 import { useAuthStore } from '~/store/auth';
 
 export const useTask = () => {
@@ -27,8 +28,37 @@ export const useTask = () => {
     }
   };
 
+  const updateTask = async (taskId: number, title: string, description: string, completed: boolean, tags: number[]) => {
+    authStore.loadToken();
+    try {
+      const response = await fetch(`${apiBaseUrl}/api/tasks/update?task_id=${taskId}`, {
+        method: 'PUT',
+        headers: {
+          'Authorization': `Bearer ${authStore.token}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          title: title,
+          description: description,
+          completed: completed,
+          tags: tags
+        })
+      })
+      const data: TaskResponse = await response.json()
+      if (response.ok) {
+        return true;
+      } else  {
+        alert(data.error)
+        return false;
+      }
+    } catch (error) {
+      console.error('An error occurred:', error)
+    }
+  }
+
   return {
     fetchTasks,
+    updateTask,
     tasks
   };
 };

--- a/pages/tasks/index.vue
+++ b/pages/tasks/index.vue
@@ -21,13 +21,17 @@
             <span>関連タグ:</span>
             <v-chip
                 v-for="tag in task.tags"
-                :key="tag"
+                :key="tag.id"
                 class="ma-1"
               >
                 <v-icon icon="mdi-label" start></v-icon>
-                {{ tag }}
+                {{ tag.name }}
               </v-chip>
           </v-card-text>
+          <v-card-actions>
+            <v-spacer />
+            <updateDialog :task="task" @taskUpdated="fetchTasks" />
+          </v-card-actions>
         </v-card>
       </v-col>
     </v-row>
@@ -37,6 +41,7 @@
 <script setup lang="ts">
 import { onMounted } from 'vue'
 import { useTask } from '~/composables/useTask';
+import updateDialog from '~/components/tasks/updateDialog.vue';
 
 const { tasks, fetchTasks} = useTask();
 

--- a/types/tag.d.ts
+++ b/types/tag.d.ts
@@ -1,0 +1,5 @@
+export type TagResponse = {
+  id: number;
+  name: string;
+  error?: string;
+};

--- a/types/task.d.ts
+++ b/types/task.d.ts
@@ -1,0 +1,9 @@
+export type TaskResponse = {
+  id: number;
+  title: string;
+  description: string;
+  completed: boolean;
+  user_id: number;
+  tags: string[];
+  error?: string;
+};

--- a/types/task.d.ts
+++ b/types/task.d.ts
@@ -1,9 +1,11 @@
+import type { TagResponse } from '~/types/tag';
+
 export type TaskResponse = {
   id: number;
   title: string;
   description: string;
   completed: boolean;
   user_id: number;
-  tags: string[];
+  tags: TagResponse[];
   error?: string;
 };


### PR DESCRIPTION
## Description
- pages/tasks/index.vue
  - 一覧画面に編集ボタン追加
- components/tasks/updateDialog.vue
  - タスク編集ダイアログ作成
- composables/useTask.ts
  - タスク編集関数記述
- types/task.d.ts
  - 関連タグtagsの型定義をTagResponse[]に変更
- composables/useTag.ts
  - タスク編集の際に既存のタグを選択するため、タグを全て取得する関数を記述
- types/tag.d.ts
  - タグレスポンスの型定義を作成
## image
![スクリーンショット 2024-10-01 16 34 42（2）](https://github.com/user-attachments/assets/591381b9-7a3b-4f94-b68b-885f4a46e090)

## Related Issues
<!--
- Add issue in other repo/url.
-->
## Review Checklist
<!--
- [ ] what to check (@foobar)
-->
## TODO
なし
<!--
- [ ] what need to be done.
  - Reason not finished in this PR.
-->
## Breaking Change
No
<!--
- Describe the impact if Yes.
-->