### PR TITLE
動的ヘッダー作成

### DIFF
--- a/components/header.vue
+++ b/components/header.vue
@@ -12,10 +12,6 @@
 
     <v-spacer></v-spacer>
 
-    <v-btn icon>
-      <v-icon>mdi-magnify</v-icon>
-    </v-btn>
-
     <v-menu offset-y>
       <template #activator="{ props }">
         <v-btn v-bind="props">

--- a/components/header.vue
+++ b/components/header.vue
@@ -1,0 +1,74 @@
+<template>
+  <v-app-bar color="surface-variant">
+    <v-tabs>
+      <v-tab
+        v-for="(menuItem, index) in filteredMenuItems"
+        :key="index"
+        :to="menuItem.link"
+      >
+        {{ menuItem.name }}
+      </v-tab>
+    </v-tabs>
+
+    <v-spacer></v-spacer>
+
+    <v-btn icon>
+      <v-icon>mdi-magnify</v-icon>
+    </v-btn>
+
+    <v-menu offset-y>
+      <template #activator="{ props }">
+        <v-btn v-bind="props">
+          <span :style="{ color: 'white' }">{{ user?.username }}</span>
+        </v-btn>
+      </template>
+
+      <v-list>
+        <v-list-item>
+          <v-btn  color="surface-variant" @click="logOut">ログアウト</v-btn>
+        </v-list-item>
+        <v-list-item>
+          <updateDialog :user="user!" />
+        </v-list-item>
+      </v-list>
+    </v-menu>
+  </v-app-bar>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, defineProps } from 'vue';
+import { useAuth } from '~/composables/useAuth'; // useAuthをインポート
+import updateDialog from './users/updateDialog.vue';
+import { UserRole } from '~/constants/userRole';
+
+// propsを受け取る
+// user プロップを受け取る
+const props = defineProps<{
+  user: {
+    id: number;
+    username: string;
+    email: string;
+    disabled: boolean;
+    role: number;
+  };
+}>();
+
+const { logOut } = useAuth(); // logOutを取得
+
+// メニュー項目を定義
+const menuItems = ref([
+  { name: 'タスク一覧', link: '/tasks' },
+  { name: 'タグ一覧', link: '/tags' },
+  { name: 'ユーザー一覧', link: '/users', roleRequired: UserRole.ADMIN }
+]);
+
+// user.roleに基づいてフィルタリングされたメニュー項目を取得
+const filteredMenuItems = computed(() => {
+  return menuItems.value.filter(menuItem => {
+    return !menuItem.roleRequired || props.user?.role === menuItem.roleRequired;
+  });
+});
+</script>
+
+<style scoped>
+</style>

--- a/components/header.vue
+++ b/components/header.vue
@@ -27,9 +27,6 @@
         <v-list-item>
           <v-btn  color="surface-variant" @click="logOut">ログアウト</v-btn>
         </v-list-item>
-        <v-list-item>
-          <updateDialog :user="user!" />
-        </v-list-item>
       </v-list>
     </v-menu>
   </v-app-bar>
@@ -38,7 +35,6 @@
 <script setup lang="ts">
 import { ref, computed, defineProps } from 'vue';
 import { useAuth } from '~/composables/useAuth'; // useAuthをインポート
-import updateDialog from './users/updateDialog.vue';
 import { UserRole } from '~/constants/userRole';
 
 // propsを受け取る

--- a/components/tasks/filterComplete.vue
+++ b/components/tasks/filterComplete.vue
@@ -1,0 +1,64 @@
+<template>
+  <v-dialog v-model="isActive" max-width="500">
+  <template v-slot:activator="{ props: activatorProps }">
+    <v-btn
+      v-bind="activatorProps"
+      color="surface-variant"
+      text="完了状態"
+      variant="flat"
+      width="100"
+    ></v-btn>
+  </template>
+
+  <template v-slot:default>
+    <v-card title="完了状態絞り込み">
+      <v-card-item>
+        <v-select
+          label="完了状態を選択してください"
+          item-title="title"
+          item-value="value"
+          :items="completedStatusOptions"
+          v-model="selectedCompleteId"
+        ></v-select>
+      </v-card-item>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn
+          text="検索"
+          :disabled="selectedCompleteId === null"
+          @click="applyFilter"
+        ></v-btn>
+      </v-card-actions>
+    </v-card>
+  </template>
+</v-dialog>
+</template>
+
+<script setup lang="ts">
+import { TaskCompleted } from '~/constants/taskCompleted';
+
+const { filterCompleted } = useTask();
+
+const emit = defineEmits(['taskFetch']);
+
+const isActive = ref<boolean>(false);
+const selectedCompleteId = ref<number | null>(null);
+
+const completedStatusOptions = [
+  { title: '未対応', value: TaskCompleted.NOT_STARTED },
+  { title: '処理中', value: TaskCompleted.IN_PROGRESS },
+  { title: '完了', value: TaskCompleted.COMPLETED },
+];
+const applyFilter = () => {
+  filterCompleted.value = selectedCompleteId.value;
+  isActive.value = false;
+  selectedCompleteId.value = null;
+  emit('taskFetch', filterCompleted.value);
+};
+
+</script>
+
+<style scoped>
+</style>
+
+

--- a/components/tasks/filterDate.vue
+++ b/components/tasks/filterDate.vue
@@ -1,0 +1,95 @@
+<template>
+  <v-dialog v-model="isActive" max-width="500">
+    <template v-slot:activator="{ props: activatorProps }">
+      <v-btn
+        v-bind="activatorProps"
+        color="surface-variant"
+        text="日付指定"
+        variant="flat"
+        width="100"
+      ></v-btn>
+    </template>
+
+    <template v-slot:default>
+      <v-card title="日付絞り込み">
+        <v-card-item>
+          <v-row>
+            <v-col cols="5">
+              <v-menu
+                v-model="menuStart"
+                :close-on-content-click="true"
+                transition="scale-transition"
+                offset-y
+              >
+                <template v-slot:activator="{ props }">
+                  <v-text-field
+                    label="開始日"
+                    variant="outlined"
+                    v-model="selectedStart"
+                    v-bind="props"
+                    readonly
+                  ></v-text-field>
+                </template>
+                <v-date-picker v-model="selectedStart" @input="menuStart = false"></v-date-picker>
+              </v-menu>
+            </v-col>
+            <v-col class="d-flex justify-center align-center">
+              <span>~</span>
+            </v-col>
+            <v-col cols="5">
+              <v-menu
+                v-model="menuEnd"
+                :close-on-content-click="true"
+                transition="scale-transition"
+                offset-y
+              >
+                <template v-slot:activator="{ props }">
+                  <v-text-field
+                    label="終了日"
+                    variant="outlined"
+                    v-model="selectedEnd"
+                    v-bind="props"
+                    readonly
+                  ></v-text-field>
+                </template>
+                <v-date-picker v-model="selectedEnd" @input="menuEnd = false"></v-date-picker>
+              </v-menu>
+            </v-col>
+          </v-row>
+        </v-card-item>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn
+            text="検索"
+            :disabled="!selectedStart || !selectedEnd"
+            @click="applyFilter"
+          ></v-btn>
+        </v-card-actions>
+      </v-card>
+    </template>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+const { filterStartDate, filterEndDate } = useTask();
+
+const emit = defineEmits(['taskFetch']);
+
+const isActive = ref(false);
+const selectedStart = ref<Date | null>(null);
+const selectedEnd = ref<Date | null>(null);
+const menuStart = ref(false);  // 開始日のメニューを制御する
+const menuEnd = ref(false);    // 終了日のメニューを制御する
+
+const applyFilter = () => {
+  filterStartDate.value = selectedStart.value;
+  filterEndDate.value = selectedEnd.value;
+  isActive.value = false;
+  selectedStart.value = null;
+  selectedEnd.value = null;
+  emit('taskFetch', filterStartDate.value, filterEndDate.value);
+};
+</script>
+
+<style scoped>
+</style>

--- a/components/tasks/filterTag.vue
+++ b/components/tasks/filterTag.vue
@@ -1,0 +1,57 @@
+<template>
+  <v-dialog v-model="isActive" max-width="500">
+  <template v-slot:activator="{ props: activatorProps }">
+    <v-btn
+      v-bind="activatorProps"
+      color="surface-variant"
+      text="タグ"
+      variant="flat"
+      width="100"
+      @click="fetchTags"
+    ></v-btn>
+  </template>
+
+  <template v-slot:default>
+    <v-card title="タグ絞り込み">
+      <v-card-item>
+        <v-select
+          label="タグを選択してください"
+          item-title="name"
+          item-value="id"
+          :items="tags"
+          v-model="selectedTagId"
+        ></v-select>
+      </v-card-item>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn
+          text="検索"
+          :disabled="!selectedTagId"
+          @click="applyFilter"
+        ></v-btn>
+      </v-card-actions>
+    </v-card>
+  </template>
+</v-dialog>
+</template>
+
+<script setup lang="ts">
+const { fetchTags, tags } = useTag();
+const { filterTagId } = useTask();
+
+const emit = defineEmits(['taskFetch']);
+
+const isActive = ref<boolean>(false);
+const selectedTagId = ref<number | null>(null);
+
+const applyFilter = () => {
+  filterTagId.value = selectedTagId.value;
+  isActive.value = false;
+  selectedTagId.value = null;
+  emit('taskFetch', filterTagId.value);
+};
+
+</script>
+
+<style scoped>
+</style>

--- a/components/tasks/searchDialog.vue
+++ b/components/tasks/searchDialog.vue
@@ -1,0 +1,58 @@
+<template>
+  <v-dialog v-model="isActive" max-width="500">
+  <template v-slot:activator="{ props: activatorProps }">
+    <v-btn
+      v-bind="activatorProps"
+      variant="flat"
+      icon="mdi-magnify"
+      color="surface-variant"
+    ></v-btn>
+  </template>
+
+  <template v-slot:default>
+    <v-card>
+      <v-card-title class="text-h5">タスク検索</v-card-title>
+      <v-card-item>
+        <v-form>
+          <v-text-field
+            v-model="title"
+            label="タグ名を入力してください"
+          ></v-text-field>
+          <v-text-field
+            v-model="description"
+            label="説明を入力してください"
+          ></v-text-field>
+        </v-form>
+      </v-card-item>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn
+          text="検索"
+          @click="_searchTask"
+          :disabled="!title && !description"
+        ></v-btn>
+      </v-card-actions>
+    </v-card>
+  </template>
+</v-dialog>
+</template>
+
+<script setup lang="ts">
+import {  } from 'vue';
+const emit = defineEmits(['taskSearch']);
+
+const isActive = ref<boolean>(false);
+const title = ref<string>('');
+const description = ref<string>('');
+
+const _searchTask = async () => {
+  emit('taskSearch', { title: title.value, description: description.value });
+  title.value = '';
+  description.value = '';
+  isActive.value = false;
+};
+
+</script>
+
+<style scoped>
+</style>

--- a/components/tasks/updateDialog.vue
+++ b/components/tasks/updateDialog.vue
@@ -6,6 +6,7 @@
       color="surface-variant"
       text="編集"
       variant="flat"
+      @click="fetchTags"
     ></v-btn>
   </template>
 

--- a/components/users/updateDialog.vue
+++ b/components/users/updateDialog.vue
@@ -4,7 +4,7 @@
     <v-btn
       v-bind="activatorProps"
       color="surface-variant"
-      text="ユーザー情報編集"
+      text="編集"
       variant="flat"
     ></v-btn>
   </template>
@@ -33,7 +33,6 @@
             label="パスワード"
           ></v-text-field>
           <v-select
-            v-if="props.user.role === UserRole.ADMIN"
             v-model="role"
             label="役割"
             item-title="title"
@@ -104,7 +103,6 @@ const _updateUser = async () => {
     emit('userFetch'); // 更新成功時にイベントを発火
   }
 };
-
 </script>
 
 <style scoped>

--- a/components/users/updateDialog.vue
+++ b/components/users/updateDialog.vue
@@ -4,7 +4,7 @@
     <v-btn
       v-bind="activatorProps"
       color="surface-variant"
-      text="編集"
+      text="ユーザー情報編集"
       variant="flat"
     ></v-btn>
   </template>
@@ -33,6 +33,7 @@
             label="パスワード"
           ></v-text-field>
           <v-select
+            v-if="props.user.role === UserRole.ADMIN"
             v-model="role"
             label="役割"
             item-title="title"

--- a/composables/useAuth.ts
+++ b/composables/useAuth.ts
@@ -22,7 +22,7 @@ export const useAuth = () => {
         authStore.setToken(data.access_token);
         navigateTo('/tasks')
       } else {
-        alert(data.error)
+        alert(data.detail)
       }
     } catch (error) {
       console.error('An error occurred:', error)

--- a/composables/useTask.ts
+++ b/composables/useTask.ts
@@ -1,10 +1,18 @@
 import { ref } from 'vue';
 import { apiBaseUrl } from '../config';
-import type { TaskResponse } from '~/types/task';
+import type { TaskResponse, PaginatedTasksResponse } from '~/types/task';
 import { useAuthStore } from '~/store/auth';
+import { TaskPagination } from '~/constants/taskPagination';
 
 export const useTask = () => {
   const tasks = ref<TaskResponse[]>([]);
+  const filterTagId = ref<number | null>(null);
+  const filterCompleted = ref<number | null>(null);
+  const filterStartDate = ref<Date | null>(null);
+  const filterEndDate = ref<Date | null>(null);
+  const page = ref<number>(TaskPagination.DEFAULT_PAGE);
+  const limit = ref<number>(TaskPagination.DEFAULT_LIMIT);
+  const totalTasks = ref<number>(TaskPagination.TOTAL_TASK);
   const authStore = useAuthStore();
 
   const createTask = async (title: string, description: string, tags: number[]) => {
@@ -25,7 +33,7 @@ export const useTask = () => {
       if (response.ok) {
         return true;
       } else  {
-        alert(data.error)
+        alert(data.detail)
         return false;
       }
     } catch (error) {
@@ -35,21 +43,45 @@ export const useTask = () => {
 
   const fetchTasks = async () => {
     try {
-      const response = await fetch(`${apiBaseUrl}/api/tasks`, {
+      // クエリパラメータを組み立て
+      const params = new URLSearchParams();
+      if (filterTagId.value !== null) params.append('tag_id', String(filterTagId.value));
+      if (filterCompleted.value !== null) params.append('completed', String(filterCompleted.value));
+      if (filterStartDate.value) params.append('start_date', filterStartDate.value.toISOString());
+      if (filterEndDate.value) params.append('end_date', filterEndDate.value.toISOString());
+      params.append('page', String(page.value));
+      params.append('limit', String(limit.value));
+
+      const queryString = params.toString() ? `?${params.toString()}` : '';
+      const response = await fetch(`${apiBaseUrl}/api/tasks${queryString}`, {
         headers: {
           'Authorization': `Bearer ${authStore.token}`
         },
       });
-      const data: TaskResponse[] = await response.json();  // データを先に取得しておく
+      const data: PaginatedTasksResponse = await response.json();  // データを先に取得しておく
       if (response.ok) {
-        tasks.value = data;
+        tasks.value = data.tasks;
+        totalTasks.value = data.total_tasks;
       } else {
-        alert(data[0]?.error || '不明なエラーが発生しました');
+        alert(data.detail || 'タスクが存在しません');
       }
     } catch (err) {
       console.error('An error occurred:', err);
       alert('タスクの取得に失敗しました');
     }
+  };
+
+  // fetchAllTasks関数を実装
+  const fetchAllTasks = async () => {
+    limit.value = 9999; // 大きな数を設定して全てのタスクを取得
+    page.value = 1; // 最初のページにリセット
+    await fetchTasks();
+  };
+
+  const fetchDefaultTasks = async () => {
+    limit.value = 6; // 大きな数を設定して全てのタスクを取得
+    page.value = 1; // 最初のページにリセット
+    await fetchTasks();
   };
 
   const updateTask = async (taskId: number, title: string, description: string, completed: number, tags: number[]) => {
@@ -71,7 +103,7 @@ export const useTask = () => {
       if (response.ok) {
         return true;
       } else  {
-        alert(data.error)
+        alert(data.detail)
         return false;
       }
     } catch (error) {
@@ -100,11 +132,54 @@ export const useTask = () => {
     }
   }
 
+  const searchTasks = async (title: string, description: string) => {
+    try {
+      // リクエストボディを初期化
+      const body: any = {};
+      // 入力されている場合のみプロパティを追加
+      if (title) {
+        body.title = title;
+      }
+      if (description) {
+        body.description = description;
+      }
+      const response = await fetch(`${apiBaseUrl}/api/tasks/search`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${authStore.token}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(body)
+      });
+      const data: TaskResponse[] = await response.json();
+      if (response.ok) {
+        tasks.value = data;
+        return true;
+      } else {
+        alert(data[0]?.detail || 'タスクが存在しません');
+        return false;
+      }
+    } catch (err) {
+      console.error('An error occurred:', err);
+      alert('タスクの取得に失敗しました');
+    }
+  };
+
   return {
     createTask,
     fetchTasks,
+    fetchAllTasks,
+    fetchDefaultTasks,
     updateTask,
     deleteTask,
-    tasks
+    searchTasks,
+    tasks,
+    totalTasks,
+    page,
+    limit,
+    filterTagId,
+    filterCompleted,
+    filterStartDate,
+    filterEndDate
   };
 };

--- a/composables/useUser.ts
+++ b/composables/useUser.ts
@@ -72,7 +72,7 @@ export const useUser = () => {
     }
   };
 
-  const updateUser = async (userId: number, username: string, email: string, password: string, role: string) => {
+  const updateUser = async (userId: number, username: string, email: string, password: string, role: number) => {
     try {
       const response = await fetch(`${apiBaseUrl}/api/user/update?user_id=${userId}`, {
         method: 'PUT',

--- a/composables/useUser.ts
+++ b/composables/useUser.ts
@@ -4,6 +4,7 @@ import { useAuthStore } from '~/store/auth';
 import type { UserResponse } from '~/types/user';
 
 export const useUser = () => {
+  const user = ref<UserResponse>();
   const users = ref<UserResponse[]>([]); // ユーザーリストを格納するref
   const error = ref<string | null>(null); // エラーを格納するref
   const authStore = useAuthStore();
@@ -40,8 +41,8 @@ export const useUser = () => {
         },
       });
       if (response.ok) {
-        const userData: UserResponse = await response.json();
-        return userData;
+        user.value = await response.json();
+        return user.value;
       } else {
         console.error('Failed to fetch user:', response.statusText);
         return null;
@@ -129,6 +130,7 @@ export const useUser = () => {
     fetchUsers,
     updateUser,
     updateUserDisabled,
-    users
+    users,
+    user
   };
 };

--- a/constants/taskPagination.ts
+++ b/constants/taskPagination.ts
@@ -1,0 +1,6 @@
+//タスクの完了状態を定義
+export const TaskPagination = {
+  TOTAL_TASK: 0,
+  DEFAULT_PAGE: 1,
+  DEFAULT_LIMIT: 6
+};

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -4,7 +4,7 @@
       style="height: 100%;"
     >
       <v-col>
-        <Header :user="user"/>
+        <Header v-if="user" :user="user"/>
         <main class="main">
           <slot />
         </main>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -4,7 +4,8 @@
       style="height: 100%;"
     >
       <v-col>
-        <main>
+        <Header :user="user"/>
+        <main class="main">
           <slot />
         </main>
       </v-col>
@@ -13,7 +14,19 @@
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue';
+import { useUser } from '~/composables/useUser'; // ユーザー情報を取得する composable をインポート
+import Header from '~/components/header.vue'; // 修正: 大文字に
+
+const { fetchUser, user } = useUser(); // fetchUser と user を取得
+
+onMounted(async () => {
+  await fetchUser(); // コンポーネントがマウントされたときにユーザー情報を取得
+});
 </script>
 
 <style scoped>
+.main {
+  padding-top: 60px;
+}
 </style>

--- a/middleware/auth.global.ts
+++ b/middleware/auth.global.ts
@@ -3,7 +3,7 @@ import { UserRole } from '~/constants/userRole';
 
 export default defineNuxtRouteMiddleware(async (to, from) => {
   const authStore = useAuthStore();
-  const { fetchUser } = useUser();
+  const { fetchUser, user } = useUser();
 
   const NOT_AUTH_PAGES = ['/signUp', '/'];
 
@@ -19,10 +19,10 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
     }
 
     if (authStore.token) {
-      const user = await fetchUser();
+      await fetchUser();
 
-      if (user) {
-        if (to.path === '/users' && user.role !== UserRole.ADMIN) {
+      if (user.value && user.value.role) { // user.value と user.value.role を確認
+        if (to.path === '/users' && user.value.role !== UserRole.ADMIN) { // user.value.role にアクセス
           return navigateTo('/tasks');
         }
       }

--- a/middleware/auth.global.ts
+++ b/middleware/auth.global.ts
@@ -3,7 +3,7 @@ import { UserRole } from '~/constants/userRole';
 
 export default defineNuxtRouteMiddleware(async (to, from) => {
   const authStore = useAuthStore();
-  const { fetchUser, user } = useUser();
+  const { fetchUser } = useUser();
 
   const NOT_AUTH_PAGES = ['/signUp', '/'];
 
@@ -19,10 +19,10 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
     }
 
     if (authStore.token) {
-      await fetchUser();
+      const user = await fetchUser();
 
-      if (user.value && user.value.role) { // user.value と user.value.role を確認
-        if (to.path === '/users' && user.value.role !== UserRole.ADMIN) { // user.value.role にアクセス
+      if (user) {
+        if (to.path === '/users' && user.role !== UserRole.ADMIN) {
           return navigateTo('/tasks');
         }
       }

--- a/pages/tasks/index.vue
+++ b/pages/tasks/index.vue
@@ -5,6 +5,40 @@
         <h1>タスク一覧</h1>
         <createDialog @taskFetch="fetchTasks" />
       </v-col>
+    </v-row>
+    <v-row class="d-flex align-center">
+      <v-col cols="12" md="3" sm="12">
+        <v-card
+          variant="tonal"
+        >
+          <v-card-item>
+            <v-row>
+              <v-col cols="4" class="d-flex justify-center">
+                <tagFilter @taskFetch="handleTagFilter" />
+              </v-col>
+              <v-col cols="4" class="d-flex justify-center">
+                <completeFilter @taskFetch="handleCompleteFilter" />
+              </v-col>
+              <v-col cols="4" class="d-flex justify-center">
+                <dateFilter @taskFetch="handleDateFilter" />
+              </v-col>
+            </v-row>
+          </v-card-item>
+        </v-card>
+      </v-col>
+      <v-spacer />
+      <v-col cols="12" md="2" sm="12" class="d-flex justify-end">
+        <searchDialog @taskSearch="handleSearch" />
+      <v-btn
+        color="surface-variant"
+        variant="flat"
+        @click="resetFilters"
+        icon="mdi mdi-rotate-right"
+        class="ms-2"
+      ></v-btn>
+    </v-col>
+    </v-row>
+    <v-row>
       <v-col
         v-for="task in tasks"
         :key="task.id"
@@ -69,21 +103,88 @@
         </v-card>
       </v-col>
     </v-row>
+    <v-row v-if="showAllButton">
+      <v-col class="d-flex justify-center">
+        <v-btn @click="fetchAllTasks">もっと見る</v-btn>
+      </v-col>
+    </v-row>
+    <v-row v-if="showPagination">
+      <v-col>
+        <v-pagination
+          v-model="page"
+          :length="totalPages"
+          @click="fetchTasks"
+        />
+      </v-col>
+    </v-row>
   </v-container>
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { onMounted, ref } from 'vue'
 import { useTask } from '~/composables/useTask';
 import createDialog from '~/components/tasks/createDialog.vue';
 import updateDialog from '~/components/tasks/updateDialog.vue';
 import deleteDialog from '~/components/tasks/deleteDialog.vue';
+import tagFilter from '~/components/tasks/filterTag.vue';
+import completeFilter from '~/components/tasks/filterComplete.vue';
+import dateFilter from '~/components/tasks/filterDate.vue';
+import searchDialog from '~/components/tasks/searchDialog.vue';
 import { TaskCompleted } from '~/constants/taskCompleted';
 import { TagColor } from '~/constants/tagColor';
 
-const { tasks, fetchTasks} = useTask();
+const { tasks, totalTasks, page, limit, filterTagId, filterCompleted, filterStartDate, filterEndDate, fetchTasks, searchTasks, fetchAllTasks, fetchDefaultTasks } = useTask();
+const { fetchTags, tags } = useTag();
 
-onMounted(fetchTasks);
+const showAllButton = ref(true);
+const showPagination = ref(false);
+
+const totalPages = computed(() => {
+  return Math.ceil(totalTasks.value / limit.value); // totalTasks を limit で割ったページ数
+});
+
+/* 600pxより小さければshowAllButtonsをtrueに設定し、それ以外の場合はfalseに設定 */
+const checkScreenSize = () => {
+  showAllButton.value = window.innerWidth < 600;
+  showPagination.value = window.innerWidth > 600;
+};
+
+const handleTagFilter = (selected: number) => {
+  filterTagId.value = selected;
+  fetchTasks();
+};
+const handleCompleteFilter = (selected: number) => {
+  filterCompleted.value = selected;
+  fetchTasks();
+};
+const handleDateFilter = (selectedStart: Date, selectedEnd: Date) => {
+  filterStartDate.value = selectedStart;
+  filterEndDate.value = selectedEnd;
+  fetchTasks();
+};
+
+const resetFilters = () => {
+  filterTagId.value = null;
+  filterCompleted.value = null;
+  filterStartDate.value = null;
+  filterEndDate.value = null;
+  fetchDefaultTasks();
+};
+
+const handleSearch = async ({ title, description }: { title: string; description: string }) => {
+  await searchTasks(title, description); // 検索条件を使用してタスクを取得
+};
+
+onMounted(async () => {
+  checkScreenSize();
+  window.addEventListener('resize', checkScreenSize);
+  await fetchTasks();
+  await fetchTags(); // タグを取得
+});
+
+onUnmounted(() => {
+  window.removeEventListener('resize', checkScreenSize);
+});
 </script>
 
 <style scoped>

--- a/types/login.d.ts
+++ b/types/login.d.ts
@@ -1,5 +1,5 @@
 export type AuthResponse = {
   access_token: string; // トークンが正常に返される場合
   token_type: string;   // トークンのタイプ (通常は "bearer")
-  error?: string;       // エラーメッセージが存在する場合
+  detail?: string;       // エラーメッセージが存在する場合
 };

--- a/types/task.d.ts
+++ b/types/task.d.ts
@@ -7,5 +7,13 @@ export type TaskResponse = {
   completed: number;
   user_id: number;
   tags: TagResponse[];
-  error?: string;
+  detail?: string;
+};
+
+export type PaginatedTasksResponse = {
+  total_tasks: number;
+  page: number;
+  limit: number;
+  tasks: TaskResponse[];
+  detail?: string;
 };


### PR DESCRIPTION
## Description
- components/header.vue
  - user.roleに応じた動的ヘッダー作成 
- composables/useUser.ts
  - 現在のユーザー情報を返す関数fetchUserを修正
- layouts/default.vue
  - headerコンポーネントにuserをpropsとして渡す
- middleware/auth.global.ts
  - userを判断する条件を変更
## image
管理者ログイン時
![スクリーンショット 2024-10-04 16 28 48（2）](https://github.com/user-attachments/assets/f78bce26-6c48-41aa-9066-7b97ca7a671c)
ユーザーログイン時
![スクリーンショット 2024-10-04 16 29 00（2）](https://github.com/user-attachments/assets/00daf962-2ddc-40f0-9e17-fc5972ed6cc4)

## Related Issues
<!--
- Add issue in other repo/url.


-->
## Review Checklist
<!--
- [ ] what to check (@foobar)
-->
## TODO
なし
<!--
- [ ] what need to be done.
  - Reason not finished in this PR.
-->
## Breaking Change
No
<!--
- Describe the impact if Yes.
-->