### PR TITLE
ページネーション実装

### DIFF
--- a/composables/useTask.ts
+++ b/composables/useTask.ts
@@ -2,6 +2,7 @@ import { ref } from 'vue';
 import { apiBaseUrl } from '../config';
 import type { TaskResponse, PaginatedTasksResponse } from '~/types/task';
 import { useAuthStore } from '~/store/auth';
+import { TaskPagination } from '~/constants/taskPagination';
 
 export const useTask = () => {
   const tasks = ref<TaskResponse[]>([]);
@@ -9,9 +10,9 @@ export const useTask = () => {
   const filterCompleted = ref<number | null>(null);
   const filterStartDate = ref<Date | null>(null);
   const filterEndDate = ref<Date | null>(null);
-  const page = ref<number>(1);
-  const limit = ref<number>(6);
-  const totalTasks = ref<number>(0);
+  const page = ref<number>(TaskPagination.DEFAULT_PAGE);
+  const limit = ref<number>(TaskPagination.DEFAULT_LIMIT);
+  const totalTasks = ref<number>(TaskPagination.TOTAL_TASK);
   const authStore = useAuthStore();
 
   const createTask = async (title: string, description: string, tags: number[]) => {

--- a/constants/taskPagination.ts
+++ b/constants/taskPagination.ts
@@ -2,5 +2,5 @@
 export const TaskPagination = {
   TOTAL_TASK: 0,
   DEFAULT_PAGE: 1,
-  DEFAULT_LIMIT: 2
+  DEFAULT_LIMIT: 6
 };

--- a/constants/taskPagination.ts
+++ b/constants/taskPagination.ts
@@ -1,0 +1,6 @@
+//タスクの完了状態を定義
+export const TaskPagination = {
+  TOTAL_TASK: 0,
+  DEFAULT_PAGE: 1,
+  DEFAULT_LIMIT: 2
+};

--- a/types/task.d.ts
+++ b/types/task.d.ts
@@ -9,3 +9,11 @@ export type TaskResponse = {
   tags: TagResponse[];
   detail?: string;
 };
+
+export type PaginatedTasksResponse = {
+  total_tasks: number;
+  page: number;
+  limit: number;
+  tasks: TaskResponse[];
+  detail?: string;
+};


### PR DESCRIPTION
## Description
- pages/tasks/index.vue
  - 一覧画面にページネーションを追加
  - 600px未満の場合はもっと見るボタンを表示
  - 600pxより大きい場合はページネーションを表示
- composables/useTask.ts
  - fetchTasks()にクエリパラメータとしてpageとlimitを追加
  - 全てのタスクを取得するためfetchAllTasks()を追加
  - タスク表示をリセットするfetchDefaultTasks()を追加
- types/task.d.ts
  - ページネーションレスポンスの型定義を実装
- constants/taskPagination.ts
  - 全タスク数、ページ数、取得データ数のデフォルト値を記載
## image
![スクリーンショット 2024-10-08 12 14 48（2）](https://github.com/user-attachments/assets/a664c26d-1855-4f2b-9b90-327987735355)
![スクリーンショット 2024-10-08 12 15 01（2）](https://github.com/user-attachments/assets/aebee52d-ee4d-47a0-ad2b-83c7b50f72d8)

## Related Issues
<!--
- Add issue in other repo/url.
-->
## Review Checklist
<!--
- [ ] what to check (@foobar)
-->
## TODO
なし
<!--
- [ ] what need to be done.
  - Reason not finished in this PR.
-->
## Breaking Change
No
<!--
- Describe the impact if Yes.
-->