### PR TITLE
カレンダー日本語表示修正

### DIFF
--- a/components/tasks/filterDate.vue
+++ b/components/tasks/filterDate.vue
@@ -21,7 +21,7 @@
               >
                 <template #activator="{ props }">
                   <v-text-field
-                    v-model="selectedStart"
+                    v-model="formattedStartDate"
                     label="開始日"
                     variant="outlined"
                     v-bind="props"
@@ -33,7 +33,6 @@
                     v-model="selectedStart"
                     title="開始日"
                     header="日付を選択"
-                    @input="menuStart = false"
                   />
                 </v-locale-provider>
               </v-menu>
@@ -50,7 +49,7 @@
               >
                 <template #activator="{ props }">
                   <v-text-field
-                    v-model="selectedEnd"
+                    v-model="formattedEndDate"
                     label="終了日"
                     variant="outlined"
                     v-bind="props"
@@ -62,7 +61,7 @@
                     v-model="selectedEnd"
                     title="終了日"
                     header="日付を選択"
-                    @input="menuEnd = false"/>
+                  />
                 </v-locale-provider>
               </v-menu>
             </v-col>
@@ -91,6 +90,18 @@ const selectedStart = ref<Date | null>(null)
 const selectedEnd = ref<Date | null>(null)
 const menuStart = ref(false) // 開始日のメニューを制御する
 const menuEnd = ref(false) // 終了日のメニューを制御する
+
+// 日付を日本語形式でフォーマットする関数
+const toJapaneseDate = (date: Date | null): string => {
+  if (!date) return ''
+  const year = date.getFullYear() // 年の値を取得する
+  const month = date.getMonth() + 1 // 月は0から始まるため1を足す, 月の値を取得する
+  const day = date.getDate() // 日の値を取得する
+  return `${year}年${month}月${day}日`
+}
+
+const formattedStartDate = computed(() => toJapaneseDate(selectedStart.value))
+const formattedEndDate = computed(() => toJapaneseDate(selectedEnd.value))
 
 const applyFilter = () => {
   filterStartDate.value = selectedStart.value

--- a/components/tasks/filterDate.vue
+++ b/components/tasks/filterDate.vue
@@ -28,7 +28,14 @@
                     readonly
                   />
                 </template>
-                <v-date-picker v-model="selectedStart" @input="menuStart = false"/>
+                <v-locale-provider locale="ja">
+                  <v-date-picker
+                    v-model="selectedStart"
+                    title="開始日"
+                    header="日付を選択"
+                    @input="menuStart = false"
+                  />
+                </v-locale-provider>
               </v-menu>
             </v-col>
             <v-col class="d-flex justify-center align-center">
@@ -50,7 +57,13 @@
                     readonly
                   />
                 </template>
-                <v-date-picker v-model="selectedEnd" @input="menuEnd = false"/>
+                <v-locale-provider locale="ja">
+                  <v-date-picker
+                    v-model="selectedEnd"
+                    title="終了日"
+                    header="日付を選択"
+                    @input="menuEnd = false"/>
+                </v-locale-provider>
               </v-menu>
             </v-col>
           </v-row>


### PR DESCRIPTION
## Description
- カレンダーヘッダー部分を日本語で表示
- 日付選択した後にyyyy年MM月dd日のフォーマットに表示を変更
## image
![スクリーンショット 2024-10-29 16 45 56（2）](https://github.com/user-attachments/assets/459461bb-365b-49c4-a7e1-333a415e2fc0)
![スクリーンショット 2024-10-29 17 21 16（2）](https://github.com/user-attachments/assets/a1d7161e-6cb9-4059-b9b8-041cb4ac1f7f)

## Related Issues
<!--
- Add issue in other repo/url.
-->
## Review Checklist
<!--
- [ ] what to check (@foobar)
-->
## TODO
なし
<!--
- [ ] what need to be done.
  - Reason not finished in this PR.
-->
## Breaking Change
No
<!--
- Describe the impact if Yes.
-->